### PR TITLE
package: use torch to speed up fft

### DIFF
--- a/Jupyter/utils.py
+++ b/Jupyter/utils.py
@@ -1,39 +1,60 @@
-import numpy as np
+import torch
 
 
 def get_args(
     m, n, aberr, array_size, wave_len, sp_size, p_size, NA, led_gap, led_height
 ):
+    device = torch.device("mps")
     scale = int(sp_size / p_size)
     m1 = m // scale
     n1 = n // scale
-    k0 = 2 * np.pi / wave_len
-    xloc, yloc = np.meshgrid(np.arange(array_size), np.arange(array_size))
-    xloc = ((xloc - (array_size - 1) / 2) * led_gap).ravel()
-    yloc = ((yloc - (array_size - 1) / 2) * led_gap).ravel()
-    kx_rel = -np.sin(np.arctan(xloc / led_height))
-    ky_rel = -np.sin(np.arctan(yloc / led_height))
+    k0 = 2 * torch.pi / wave_len
+
+    xloc, yloc = torch.meshgrid(
+        torch.arange(array_size, device=device),
+        torch.arange(array_size, device=device),
+        indexing="ij",
+    )
+    xloc = ((xloc - (array_size - 1) / 2) * led_gap).reshape(-1)
+    yloc = ((yloc - (array_size - 1) / 2) * led_gap).reshape(-1)
+
+    kx_rel = -torch.sin(torch.atan(xloc / led_height))
+    ky_rel = -torch.sin(torch.atan(yloc / led_height))
     kx = k0 * kx_rel
     ky = k0 * ky_rel
-    dkx = 2 * np.pi / (n * p_size)
-    dky = 2 * np.pi / (m * p_size)
+
+    dkx = 2 * torch.pi / (n * p_size)
+    dky = 2 * torch.pi / (m * p_size)
     cutoff = NA * k0
-    kmax = np.pi / sp_size
-    kxm, kym = np.meshgrid(np.linspace(-kmax, kmax, n1), np.linspace(-kmax, kmax, m1))
-    ctf = kxm**2 + kym**2 < cutoff**2
+    kmax = torch.pi / sp_size
+
+    kxm, kym = torch.meshgrid(
+        torch.linspace(-kmax, kmax, n1, device=device),
+        torch.linspace(-kmax, kmax, m1, device=device),
+        indexing="ij",
+    )
+
+    ctf = (kxm**2 + kym**2) < (cutoff**2)
+
     pupil = None
     if aberr is not None:
         z = aberr
-        kzm = np.sqrt(k0**2 - kxm**2 - kym**2)
-        pupil = np.exp(1j * z * np.real(kzm)) * np.exp(-abs(z) * np.abs(np.imag(kzm)))
-    return ctf, pupil, kx, ky, dkx, dky, m1, n1
+        kzm_sq = k0**2 - kxm**2 - kym**2
+        kzm = torch.sqrt(torch.clamp(kzm_sq, min=0.0)) + 1j * torch.sqrt(
+            torch.clamp(-kzm_sq, min=0.0)
+        )
+        pupil = torch.exp(1j * z * torch.real(kzm)) * torch.exp(
+            -abs(z) * torch.abs(torch.imag(kzm))
+        )
+
+    return ctf.float(), pupil, kx, ky, dkx, dky, m1, n1
 
 
 def gseq(array_size):
     assert array_size % 2 == 1, "NotImplemented: only support odd array_size yet."
-    n = (array_size + 1) / 2
-    seq = np.zeros((2, array_size**2), dtype=int)
-    seq[0][0], seq[1][0] = n, n
+    n = (array_size + 1) // 2
+    seq = torch.zeros((2, array_size**2), dtype=torch.int32)
+    seq[0, 0], seq[1, 0] = n, n
     dx, dy = +1, -1
     stepx, stepy = +1, -1
     direction = +1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-numpy==1.25.0
+torch
+torchvision
 jupyter
 matplotlib
 poppy


### PR DESCRIPTION
Use PyTorch to speed up FFT calculations with GPU (MPS backend).

-----
Completed the test outlined in [issue#1](https://github.com/NekoAsakura/Fourier-Ptychography/issues/1).
Test script:

```python
import time
import numpy as np
import matplotlib.pyplot as plt
import pyfftw
import torch
from tqdm import tqdm

sizes = [256, 512, 1024]
iter = 1000
libraries = ['NumPy \n(Accelerate BLAS)', 'pyFFTW', 'PyTorch \n(MPS)']

def run_numpy_fft(n):
    data = np.random.randn(n, n) + 1j * np.random.randn(n, n)
    start_time = time.perf_counter()
    for _ in tqdm(range(iter), desc=f"NumPy FFT {n}x{n}", leave=False):
        np.fft.fft2(data)
    end_time = time.perf_counter()
    return end_time - start_time

def run_pyfftw_fft(n):
    a = pyfftw.empty_aligned((n, n), dtype='complex128')
    b = pyfftw.empty_aligned((n, n), dtype='complex128')
    a[:] = np.random.randn(n, n) + 1j * np.random.randn(n, n)
    fft_object = pyfftw.FFTW(a, b, axes=(0, 1))
    start_time = time.perf_counter()
    for _ in tqdm(range(iter), desc=f"pyFFTW FFT {n}x{n}", leave=False):
        fft_object()
    end_time = time.perf_counter()
    return end_time - start_time

def run_pytorch_fft(n):
    device = torch.device("mps")
    data_real = torch.randn(n, n, device=device)
    data_imag = torch.randn(n, n, device=device)
    data = torch.complex(data_real, data_imag)
    _ = torch.fft.fft2(data)
    torch.mps.synchronize()
    start_time = time.perf_counter()
    for _ in tqdm(range(iter), desc=f"PyTorch FFT {n}x{n}", leave=False):
        _ = torch.fft.fft2(data)
        torch.mps.synchronize()
    end_time = time.perf_counter()
    return end_time - start_time

results = {size: [] for size in sizes}

for n in sizes:
    results[n].append(run_numpy_fft(n))
    results[n].append(run_pyfftw_fft(n))
    results[n].append(run_pytorch_fft(n))

fig, axes = plt.subplots(1, 3, figsize=(15, 6))

for idx, n in enumerate(sizes):
    ax = axes[idx]
    times = results[n]
    ax.bar(libraries, times, color=['skyblue', 'salmon', 'lightgreen'])
    ax.set_title(f'{n}x{n} FFT')
    ax.set_ylabel('Time (sec)')
    ax.set_xticklabels(libraries, rotation=0, ha='right')
    ax.grid(axis='y')

plt.suptitle('FFT Performance Comparison')
plt.tight_layout(rect=[0, 0, 1, 0.95])
plt.show()

```

![FFT_perf](https://github.com/user-attachments/assets/a2fbff07-ed19-41e9-9c71-48f8abb4dff4)
